### PR TITLE
There were calls that did not pass auth to arcgis-rest-js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.6.1
+## 1.7.1
+### Fixed
+- getById, getAttachmentsById were not passing the session auth to ArcGIS Rest JS
+
+## 1.7.0
 ### Fixed
 - update token logic to handle cases where services have UPCASED server names, but portalHostname is lowercase.
 

--- a/addon/mixins/ags-service-mixin.js
+++ b/addon/mixins/ags-service-mixin.js
@@ -90,6 +90,7 @@ export default Mixin.create({
   * Returns stuff like version, services and folders
    */
   getServerInfo (url, options) {
+    debug(`WARNING: service-mixin.getServerInfo does not use ArcGIS Rest JS.`);
     const serviceUrl = parseServiceUrl(url);
     let service = url;
     if (serviceUrl) {
@@ -102,6 +103,7 @@ export default Mixin.create({
    * Get the authentication information from a server.
    */
   getAuthInfo (url, options) {
+    debug(`WARNING: service-mixin.getAuthInfo does not use ArcGIS Rest JS.`);
     let server = url;
     const serverUrl = parseServerUrl(url);
     if (serverUrl) {

--- a/addon/services/feature-service.js
+++ b/addon/services/feature-service.js
@@ -1,8 +1,8 @@
 import Service from '@ember/service';
 import serviceMixin from '../mixins/ags-service-mixin';
 import layerMixin from '../mixins/layers';
+import { debug } from '@ember/debug';
 import {
-  getFeature,
   addFeatures,
   updateFeatures,
   deleteFeatures,
@@ -14,14 +14,9 @@ export default Service.extend(serviceMixin, layerMixin, {
   /**
    * Get a record by id
    */
-  getById (url, id) {
-    // why is there an optionless getById() here and another in mixins/layers.js?
-    return getFeature({
-      url,
-      id,
-      httpMethod: "GET"
-    });
-  },
+  // getById (url, id) {
+  // ***> implemented in layerMixin
+  // },
 
   /**
    * Get attachments for a record by id
@@ -30,7 +25,8 @@ export default Service.extend(serviceMixin, layerMixin, {
     return getAttachments({
       url,
       featureId: id,
-      httpMethod: 'GET'
+      httpMethod: 'GET',
+      authentication: this.get('session.authMgr')
     })
   },
 
@@ -63,6 +59,7 @@ export default Service.extend(serviceMixin, layerMixin, {
    * data.keywords
    */
   updateAttachment (url, data, token) {
+    debug(`WARNING: feature-service.updateAttachment does not use ArcGIS Rest JS.`);
     // the feature id must already be embedded in the url
     url = url + '/updateAttachment?f=json';
     return this.attachmentsRequest(url, data, token);
@@ -97,6 +94,7 @@ export default Service.extend(serviceMixin, layerMixin, {
    * data.keywords
    */
   addAttachment (url, data, token) {
+    debug(`WARNING: feature-service.addAttachment does not use ArcGIS Rest JS.`);
     url = url + '/addAttachment?f=json';
     return this.attachmentsRequest(url, data, token);
   },
@@ -129,6 +127,7 @@ export default Service.extend(serviceMixin, layerMixin, {
    * data.keywords
    */
   deleteAttachments (url, data, token) {
+    debug(`WARNING: feature-service.deleteAttachments does not use ArcGIS Rest JS.`);
     url = url + '/deleteAttachments?f=json';
     return this.attachmentsRequest(url, data, token);
   },
@@ -155,6 +154,7 @@ export default Service.extend(serviceMixin, layerMixin, {
   },
 
   attachmentsRequest (url, data, token) {
+    debug(`WARNING: feature-service.attachmentsRequest does not use ArcGIS Rest JS.`);
     let options = {
       method: 'POST',
       mimeType: 'multipart/form-data',

--- a/tests/unit/services/feature-service-test.js
+++ b/tests/unit/services/feature-service-test.js
@@ -16,4 +16,5 @@ module('Unit | Service | feature service', function(hooks) {
     let service = this.owner.lookup('service:feature-service');
     assert.ok(service);
   });
+
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -8342,7 +8342,7 @@ walk-sync@0.3.2:
     ensure-posix-path "^1.0.0"
     matcher-collection "^1.0.0"
 
-walk-sync@^0.2.5:
+walk-sync@^0.2.5, walk-sync@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/walk-sync/-/walk-sync-0.2.7.tgz#b49be4ee6867657aeb736978b56a29d10fa39969"
   integrity sha1-tJvk7mhnZXrrc2l4tWop0Q+jmWk=


### PR DESCRIPTION
`getById` and `getAttachmentsById` were not passing the session auth to ArcGIS Rest JS

This also adds debug warnings on the other methods that are not currently relying on the ArcGIS Rest JS `feature-service` package. Under some circumstances, server federation logic may be incorrect for those calls.

Also made an attempt to use fetch-mock to validate the calls made thru ArcGIS Rest JS, but that failed.